### PR TITLE
fix: replace hardcoded year with dynamic current year

### DIFF
--- a/src/data/app.js
+++ b/src/data/app.js
@@ -1,4 +1,6 @@
-{
+const year = new Date().getFullYear();
+
+export default {
   "settings": {
     "formspreeURL": "https://formspree.io/f/myyqbpqq",
     "mailchimp": {
@@ -25,26 +27,11 @@
         "label": "Committees",
         "link": "#.",
         "children": [
-          {
-            "label": "UNSC",
-            "link": "/unsc"
-          },
-          {
-            "label": "UNHRC",
-            "link": "/unhrc"
-          },
-          {
-            "label": "AIPPM",
-            "link": "/aippm"
-          },
-          {
-            "label": "WTO",
-            "link": "/wto"
-          },
-          {
-            "label": "IP",
-            "link": "/ip"
-          }
+          { "label": "UNSC", "link": "/unsc" },
+          { "label": "UNHRC", "link": "/unhrc" },
+          { "label": "AIPPM", "link": "/aippm" },
+          { "label": "WTO", "link": "/wto" },
+          { "label": "IP", "link": "/ip" }
         ]
       },
       {
@@ -52,13 +39,13 @@
         "link": "#.",
         "children": [
           {
-            "label": "2023",
+            "label": year.toString(),
             "link": "https://drive.google.com/file/d/13lmwCpRqGLJcrz9oigoFa30jJRpMsgIO/view?usp=share_link"
           }
         ]
       },
       {
-        "label": "TENET 2026",
+        "label": `TENET ${year}`,
         "link": "https://www.ioittenet.com/",
         "children": []
       }
@@ -67,48 +54,24 @@
   "footer": {
     "logo": {
       "text": "AISSMS IOIT",
-      "accent": " MUN' 26",
+      "accent": ` MUN' ${year.toString().slice(-2)}`,
       "image1": "/img/hero/ioitAcm.png",
       "image2": "/img/hero/mun12.png"
     },
     "description": "",
     "menu": [
-      {
-        "label": "Homepage",
-        "link": "/"
-      },
-      {
-        "label": "Secretariat",
-        "link": "/secretariat"
-      },
-      {
-        "label": "Gallery",
-        "link": "/gallery"
-      },
-      {
-        "label": "TENET 2026",
-        "link": "https://ioittenet.com/"
-      }
+      { "label": "Homepage", "link": "/" },
+      { "label": "Secretariat", "link": "/secretariat" },
+      { "label": "Gallery", "link": "/gallery" },
+      { "label": `TENET ${year}`, "link": "https://ioittenet.com/" }
     ],
     "links": [
-      {
-        "label": "Terms",
-        "link": "#."
-      },
-      {
-        "label": "Careers",
-        "link": "#."
-      },
-      {
-        "label": "Privacy Policy",
-        "link": "#."
-      },
-      {
-        "label": "Help Center",
-        "link": "#."
-      }
+      { "label": "Terms", "link": "#." },
+      { "label": "Careers", "link": "#." },
+      { "label": "Privacy Policy", "link": "#." },
+      { "label": "Help Center", "link": "#." }
     ],
-    "copy": "© 2026 IOIT MUN. All Rights Reserved.",
+    "copy": `© ${year} IOIT MUN. All Rights Reserved.`,
     "dev": "Developed by: IOIT ACM Student Chapter",
     "instagram": {
       "images": [

--- a/src/layouts/footers/LayoutDefault.js
+++ b/src/layouts/footers/LayoutDefault.js
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import appData from "@data/app.json";
+import appData from "@/src/data/app";
 import Image from "next/image";
 
 const DefaultFooter = ( { instagram } ) => {

--- a/src/layouts/footers/LayoutTwo.js
+++ b/src/layouts/footers/LayoutTwo.js
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import appData from "@data/app.json";
+import appData from "@/src/data/app";
 
 const Footer2 = ( { extraClass } ) => {
   return (

--- a/src/layouts/headers/LayoutDefault.js
+++ b/src/layouts/headers/LayoutDefault.js
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { useState } from "react";
-import appData from "@data/app.json";
+import appData from "@/src/data/app";
 import Image from "next/image";
 
 const DefaultHeader = ({ transparent, invert, extraClass }) => {

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -77,6 +77,20 @@ class MyDocument extends Document {
           <link rel="apple-touch-icon" href="/img/logo.png" />
           <meta name="theme-color" content="#00274D" />
 
+          {/* Google tag (gtag.js) */}
+          <Script
+            src="https://www.googletagmanager.com/gtag/js?id=G-5DSYN8WKPN"
+            strategy="afterInteractive"
+          />
+          <Script id="google-analytics" strategy="afterInteractive">
+            {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-5DSYN8WKPN');
+            `}
+          </Script>
+
           {/* JSON-LD Structured Data (Event) */}
           <script
             type="application/ld+json"

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -3,7 +3,10 @@ import Script from "next/script";
 import { Analytics } from "@vercel/analytics/react";
 
 class MyDocument extends Document {
+
+
   render() {
+    const year = new Date().getFullYear();
     return (
       <Html lang="en">
         <Head>
@@ -14,24 +17,36 @@ class MyDocument extends Document {
             name="viewport"
             content="width=device-width, initial-scale=1, maximum-scale=5"
           />
+
           <meta
             name="description"
-            content="IOIT MUN 2026 — A premier Model United Nations conference hosted by IOIT, uniting delegates worldwide to debate, negotiate, and shape global policy."
+            content={`IOIT MUN ${year} — A premier Model United Nations conference hosted by IOIT, uniting delegates worldwide to debate, negotiate, and shape global policy.`}
           />
+
           <meta
             name="keywords"
-            content="IOIT MUN 2026, Model United Nations, IOIT, Debate, Diplomacy, International Relations, Student Conference, Pune"
+            content={`IOIT MUN ${year}, Model United Nations, IOIT, Debate, Diplomacy, International Relations, Student Conference, Pune`}
           />
-          <meta name="author" content="IOIT MUN 2026 Secretariat" />
+
+          <meta
+            name="author"
+            content={`IOIT MUN ${year} Secretariat`}
+          />
 
           {/* Open Graph / Facebook */}
-          <meta property="og:title" content="IOIT MUN 2026 | Model United Nations" />
+          <meta
+            property="og:title"
+            content={`IOIT MUN ${year} | Model United Nations`}
+          />
+
           <meta
             property="og:description"
-            content="Join IOIT MUN 2026 at IOIT, Pune — experience world-class debate, diplomacy, and leadership with future changemakers."
+            content={`Join IOIT MUN ${year} at IOIT, Pune — experience world-class debate, diplomacy, and leadership with future changemakers.`}
           />
+
           <meta property="og:type" content="website" />
           <meta property="og:url" content="https://mun.ioittenet.com" />
+
           <meta
             property="og:image"
             content="https://mun.ioittenet.com/img/mockmun.png"
@@ -39,35 +54,28 @@ class MyDocument extends Document {
 
           {/* Twitter Cards */}
           <meta name="twitter:card" content="summary_large_image" />
-          <meta name="twitter:title" content="IOIT MUN 2026 | Model United Nations" />
+
+          <meta
+            name="twitter:title"
+            content={`IOIT MUN ${year} | Model United Nations`}
+          />
+
           <meta
             name="twitter:description"
-            content="Global diplomacy starts here. Be part of IOIT MUN 2026."
+            content={`Global diplomacy starts here. Be part of IOIT MUN ${year}.`}
           />
+
           <meta
             name="twitter:image"
             content="https://mun.ioittenet.com/img/mockmun.png"
           />
+
           <meta name="twitter:site" content="@ioitmun" />
 
           {/* Favicon & Theme */}
           <link rel="icon" href="/img/favicon.ico" />
           <link rel="apple-touch-icon" href="/img/logo.png" />
           <meta name="theme-color" content="#00274D" />
-
-          {/* Google tag (gtag.js) */}
-          <Script
-            src="https://www.googletagmanager.com/gtag/js?id=G-5DSYN8WKPN"
-            strategy="afterInteractive"
-          />
-          <Script id="google-analytics" strategy="afterInteractive">
-            {`
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', 'G-5DSYN8WKPN');
-            `}
-          </Script>
 
           {/* JSON-LD Structured Data (Event) */}
           <script
@@ -76,24 +84,24 @@ class MyDocument extends Document {
               __html: JSON.stringify({
                 "@context": "https://schema.org",
                 "@type": "Event",
-                name: "IOIT MUN 2026",
+                name: `IOIT MUN ${year}`,
                 startDate: "2025-10-11",
                 endDate: "2025-10-12",
-                eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+                eventAttendanceMode:
+                  "https://schema.org/OfflineEventAttendanceMode",
                 eventStatus: "https://schema.org/EventScheduled",
                 location: {
                   "@type": "Place",
                   name: "Institute of Information Technology (IOIT), Pune",
-                  address: "IOIT Campus, Pune, India"
+                  address: "IOIT Campus, Pune, India",
                 },
                 image: ["https://mun.ioittenet.com/img/mockmun.png"],
-                description:
-                  "IOIT MUN 2026 is a premier Model United Nations conference uniting delegates worldwide to debate, negotiate, and shape global policy.",
+                description: `IOIT MUN ${year} is a premier Model United Nations conference uniting delegates worldwide to debate, negotiate, and shape global policy.`,
                 organizer: {
                   "@type": "Organization",
                   name: "IOIT MUN Secretariat",
-                  url: "https://mun.ioittenet.com"
-                }
+                  url: "https://mun.ioittenet.com",
+                },
               }),
             }}
           />


### PR DESCRIPTION
## Changes Made

- Renamed `src/data/app.json` to `src/data/app.js` and updated it to use the newer export-based format, since the previous JSON structure did not support JavaScript exports.
- Added dynamic year updation in `src/pages/_document.js` to replace the hardcoded year value.

## Why

The older JSON structure was outdated and limited for the current setup. Migrating to a JavaScript module allows exports and improves maintainability.  
The dynamic year update ensures the displayed year stays automatically up to date without requiring manual changes every year.

Fixes #32 