### PR TITLE
fix: add 2024 and 2025 newsletter links to navbar dropdown

### DIFF
--- a/src/data/app.js
+++ b/src/data/app.js
@@ -39,7 +39,15 @@ export default {
         "link": "#.",
         "children": [
           {
-            "label": year.toString(),
+            "label": 2025,
+            "link": "https://drive.google.com/file/d/1KkG7dR_6oTYN4YPEFijmY1KkZUxYHSH3/view?usp=sharing"
+          },
+          {
+            "label": 2024,
+            "link": "https://drive.google.com/file/d/1iU8YuglSMDZts1aawuNMd4zadD_mew3d/view?usp=sharing"
+          },
+          {
+            "label": 2023,
             "link": "https://drive.google.com/file/d/13lmwCpRqGLJcrz9oigoFa30jJRpMsgIO/view?usp=share_link"
           }
         ]


### PR DESCRIPTION
## What does this PR do?
Fixes the newsletter dropdown in the navbar to show correct links 
for all previous year newsletters.

## Problem
The newsletter dropdown only had a 2026 entry which was redirecting 
to the 2023 newsletter PDF. The 2024 and 2025 newsletters were 
completely missing from the dropdown.

## Changes Made
- Fixed 2023 newsletter link to point to the correct document
- Added 2025 newsletter link to the navbar dropdown
- Added 2024 newsletter link to the navbar dropdown

All links are Google Drive PDFs set to "Anyone with the link can view".

<img width="1907" height="1027" alt="image" src="https://github.com/user-attachments/assets/7312e1ba-e596-45ae-8db0-e0cf809da2a4" />


Fixes #36